### PR TITLE
fix(Element): `Add-OrgElement` parameter handling

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -13,4 +13,7 @@ param(
     $ModuleName = 'PSOrgMode'
 )
 
+
 . ./build/BuildTool.ps1
+
+task Test analyzer_test_source

--- a/CodeFormattingSettings.psd1
+++ b/CodeFormattingSettings.psd1
@@ -1,0 +1,55 @@
+@{
+    IncludeRules = @(
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'PSUseConsistentWhitespace',
+        'PSUseConsistentIndentation',
+        'PSAlignAssignmentStatement',
+        'PSUseCorrectCasing'
+    )
+
+    Rules        = @{
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $false
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $true
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable          = $false
+            Kind            = 'space'
+            PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+            IndentationSize = 4
+        }
+
+        PSUseConsistentWhitespace  = @{
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhitespace = $true
+            CheckSeparator                  = $true
+            CheckParameter                  = $true
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+
+        PSUseCorrectCasing     = @{
+            Enable             = $true
+        }
+    }
+}

--- a/PSOrgMode/PSOrgMode.psm1
+++ b/PSOrgMode/PSOrgMode.psm1
@@ -29,7 +29,7 @@ if (Test-Path "$PSScriptRoot\LoadOrder.txt") {
                     # blank line, skip
                     continue
                 }
-                '^\s*#$' {
+                '^\s*#.*$' {
                     # Comment line, skip
                     continue
                 }

--- a/PSOrgMode/private/Element/Add-OrgElement.ps1
+++ b/PSOrgMode/private/Element/Add-OrgElement.ps1
@@ -1,30 +1,59 @@
 
-Function Add-OrgElement {
-<#
-.SYNOPSIS
-    Add a Child Item to an OrgElement
-#>
+function Add-OrgElement {
+ <#
+ .SYNOPSIS
+     Add a Child Item to an OrgElement
+ .DESCRIPTION
+     Parsing an orgmode buffer creates an object hierarchy, where each
+     Element has a Parent|Child relationship.  An element has 0 or 1
+     Parent and 0 or more Children.
+    - Sets the `Parent` property of the Elements passed to the `Child`
+       parameter
+     - Adds all elements passed to the `Child` parameter to the Children[]
+       property of the element passed to the `Parent` parameter
+ .EXAMPLE
+     ```powershell
+     $root | Add-OrgElement $heading
+     ```
+     Sets the $heading element as a child of $root
+ .EXAMPLE
+     ```powershell
+     $root | Add-OrgElement $heading -PassThru | Get-OrgHeadline
+     ```
+     Setting the `PassThru` parameter passes the $root element to
+     `Get-OrgHeadline`
+ .NOTES
+     This function is not exported.
+ .LINK
+     New-OrgElement
+     Get-OrgElement
+ #>
     [CmdletBinding()]
     param(
-        # Child object to add
-        [Parameter(
-            Mandatory = $true,
-            ValueFromPipeline = $true
-        )]
-        [OrgElement]
-        $Child,
-
-        # Element to add to
+        # The OrgElement to add the other OrgElement to
         [Parameter(
             Mandatory = $true,
             ValueFromPipeline = $true
         )]
         [Alias('To')]
+        [ValidateNotNullOrEmpty()]
         [OrgElement]
         $Parent,
 
-        # Optionally return the Child element to
-        # the pipeline
+        # One or more OrgElements to add
+        [Parameter(
+            Position = 0,
+            Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromRemainingArguments = $true
+        )]
+        [ValidateNotNullOrEmpty()]
+        [OrgElement[]]
+        $Child,
+
+        # When set, `Add-OrgElement` will return the Parent element to
+        # the pipeline for further processing
+        # Nothing is returned by default
         [Parameter(
             Mandatory = $false,
             ValueFromPipeline = $false
@@ -36,17 +65,19 @@ Function Add-OrgElement {
     # or fail out
     begin {}
     process {
-        try {
-            $Parent.Children.Add($Child) | Out-Null
-            $Child.addParent($Parent)
+        Write-Debug "Adding $($Child.count) to $($Parent.type)"
+        foreach ($c in $Child) {
+            try {
+                $Parent.Children.Add($c) | Out-Null
+                $c.addParent($Parent)
 
-            Write-Debug "Parent set to : $($Child.Parent.Type)"
-        }
-        catch {
-            Write-Error "Unable to add the $($Child.Type) to $($Parent.Type)`n$_"
+                Write-Debug "Parent set to : $($c.Parent.Type)"
+            } catch {
+                Write-Error "Unable to add the $($c.Type) to $($Parent.Type)`n$_"
+            }
         }
     }
     end {
-        if ($PassThru) { $Child }
+        if ($PassThru) { $Parent }
     }
 }

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,25 +1,85 @@
 @{
+    #region Severity
+    Severity              = @()
+    #endregion Severity
 
-    # Severity=@()
+    #region ExcludeRules
+    # Omits the specified rules from the Script Analyzer test. Wildcard characters are supported.
 
-    # ExcludeRules=@()
+    # Enter a comma-separated list of rule names, a variable that contains rule names, or a command that gets rule names. You can also specify a list of excluded rules in a Script Analyzer profile file. You
+    # can exclude standard rules and rules in a custom rule path.
 
+    # When you exclude a rule, the rule does not run on any of the files in the path. To exclude a rule on a particular line, parameter, function, script, or class, adjust the Path parameter or suppress the
+    # rule. For information about suppressing a rule, see the examples.
 
-    IncludeDefaultRules = $true
+    # If a rule is specified in both the ExcludeRule and IncludeRule collections, the rule is excluded.
+    ExcludeRules          = @()
+    #endregion ExcludeRules
 
-    # IncludeRules        = @()
+    #region IncludeDefaultRules
+    # Invoke default rules along with Custom rules.
+    IncludeDefaultRules   = $true
+    #endregion IncludeDefaultRules
 
-    Rules = @{
+    #region IncludeRules
+    # Runs only the specified rules in the Script Analyzer test. By default, PSScriptAnalyzer runs all
+    # rules.
+
+    # Enter a comma-separated list of rule names, a variable that contains rule names, or a command that
+    # gets rule names. Wildcard characters are supported. You can also specify rule names in a Script
+    # Analyzer profile file.
+
+    # When you use the **CustomizedRulePath** parameter, you can use this parameter to include standard
+    # rules and rules in the custom rule paths.
+
+    # If a rule is specified in both the **ExcludeRule** and **IncludeRule** collections, the rule is
+    # excluded.
+
+    # The **Severity** parameter takes precedence over **IncludeRule**. For example, if **Severity** is
+    # `Error`, you cannot use **IncludeRule** to include a `Warning` rule.
+    IncludeRules          = @()
+    #endregion IncludeRules
+
+    #region Rules
+    # Some rules have their own settings.  Rules is a hash of Rule names with
+    # the rule settings as a hash, like
+    # ``` powershell
+    # @{
+    #     'Rules' = @{
+    #         'PSAvoidUsingCmdletAliases' = @{
+    #             'allowlist' = @('cd')
+    #         }
+    #     }
+    # }
+    # ```
+    Rules                 = @{
         PSAvoidUsingCmdletAliases = @{
             Whitelist = @(
                 'task'
-                )
+            )
         }
     }
+    #endregion Rules
 
-    CustomRulePath = @(
+    #region CustomRulePath
+    # Uses only the custom rules defined in the specified paths to the analysis. To still use the built-in rules, add the -IncludeDefaultRules switch.
+
+    # Enter the path to a file that defines rules or a directory that contains files that define rules. Wildcard characters are supported. To add rules defined in subdirectories of the path, use the
+    # RecurseCustomRulePath parameter.
+
+    # By default, Invoke-ScriptAnalyzer uses only rules defined in the Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll file in the PSScriptAnalyzer module.
+
+    # If Invoke-ScriptAnalyzer cannot find rules in the CustomRulePath, it runs the standard rules without notice.
+
+    CustomRulePath        = @(
         "build/rules"
     )
+    #endregion CustomRulePath
 
+    #region RecurseCustomRulePath
+    # Adds rules defined in subdirectories of the **CustomRulePath** location. By default,
+    # `Invoke-ScriptAnalyzer` uses only the custom rules defined in the specified file or directory. To
+    # include the built-in rules, use the **IncludeDefaultRules** parameter.
     RecurseCustomRulePath = $true
+    #endregion RecurseCustomRulePath
 }

--- a/tests/Element/Add-OrgElement.Tests.ps1
+++ b/tests/Element/Add-OrgElement.Tests.ps1
@@ -1,8 +1,23 @@
 
-Describe "Testing private Element function Add-OrgElement" -Tags @('unit', 'OrgElement', 'Add' ) {
-    Context "Basic functionality" {
-        It "Should load without error" {
-            {Get-Help Add-OrgElement -ErrorAction Stop} | Should -Not -Throw
+InModuleScope -ModuleName 'PSOrgMode' {
+    Describe 'Testing private Element function Add-OrgElement' -Tags @('unit', 'OrgElement', 'Add' ) {
+        Context 'Basic functionality' {
+            It 'Should load without error' {
+                { Get-Help Add-OrgElement -ErrorAction Stop } | Should -Not -Throw
+            }
+        }
+        Context 'When Parent is passed on the pipeline and Child(ren) are Args' {
+            BeforeAll {
+                $root = New-OrgElement -Type orgdata
+                $h = New-OrgElement -Type headline
+                $h.level = 1
+                $h.title = 'a test heading'
+            }
+            It 'Should add the arguments to the pipeline element' {
+                $root | Add-OrgElement $h
+                $root.Children[0].level | Should -Be 1
+                $root.Children[0].title | Should -Be 'a test heading'
+            }
         }
     }
 }

--- a/tests/Module/AnalyzeSource.Tests.ps1
+++ b/tests/Module/AnalyzeSource.Tests.ps1
@@ -1,7 +1,7 @@
 
 
 BeforeDiscovery {
-    $sourceFiles = Get-ChildItem $Source.Path -Filter "*.ps1" -Recurse | Get-SourceComponent
+    $sourceFiles = Get-ChildItem $Source.Path -Filter "*.ps1" -Recurse | Get-SourceItem
     # Gather rules during discovery, so we can use the 'foreach' below
     $analyzerRules = Get-ScriptAnalyzerRule
 }

--- a/tests/Module/CommentBasedHelp.Tests.ps1
+++ b/tests/Module/CommentBasedHelp.Tests.ps1
@@ -1,11 +1,5 @@
 
-Describe "$ModuleName Sanity Tests - Help Content" -Tags 'analyze' {
-
-    #region Discovery
-
-    # The module will need to be imported during Discovery since we're using it to generate test cases / Context blocks
-    Import-Module $Source.Module
-
+BeforeDiscovery {
     $ShouldProcessParameters = 'WhatIf', 'Confirm'
 
     # Generate command list for generating Context / TestCases
@@ -15,64 +9,55 @@ Describe "$ModuleName Sanity Tests - Help Content" -Tags 'analyze' {
         $Module.ExportedCmdlets.Keys
     )
 
-    #endregion Discovery
+}
 
-    foreach ($Command in $CommandList) {
-        Context "$Command - Help Content" {
-
-            #region Discovery
-
-            $Help = @{ Help = Get-Help -Name $Command -Full | Select-Object -Property * }
-            $Parameters = Get-Help -Name $Command -Parameter * -ErrorAction Ignore |
-                Where-Object { $_.Name -and $_.Name -notin $ShouldProcessParameters } |
-                ForEach-Object {
-                    @{
-                        Name        = $_.name
-                        Description = $_.Description.Text
-                    }
-                }
-            $Ast = @{
-                # Ast will be $null if the command is a compiled cmdlet
-                Ast        = (Get-Content -Path "function:/$Command" -ErrorAction Ignore).Ast
-                Parameters = $Parameters
-            }
-            $Examples = $Help.Help.Examples.Example | ForEach-Object { @{ Example = $_ } }
-
-            #endregion Discovery
-
-            It "has help content for $Command" -TestCases $Help {
-                $Help | Should -Not -BeNullOrEmpty
-            }
-
-            It "contains a synopsis for $Command" -TestCases $Help {
-                $Help.Synopsis | Should -Not -BeNullOrEmpty
-            }
-
-            It "contains a description for $Command" -TestCases $Help {
-                $Help.Description | Should -Not -BeNullOrEmpty
-            }
-
-            It "lists the function author in the Notes section for $Command" -TestCases $Help {
-                $Notes = $Help.AlertSet.Alert.Text -split '\n'
-                $Notes[0].Trim() | Should -BeLike "Author: *"
-            }
-
-            # This will be skipped for compiled commands ($Ast.Ast will be $null)
-            It "has a help entry for all parameters of $Command" -TestCases $Ast -Skip:(-not ($Parameters -and $Ast.Ast)) {
-                @($Parameters).Count | Should -Be $Ast.Body.ParamBlock.Parameters.Count -Because 'the number of parameters in the help should match the number in the function script'
-            }
-
-            It "has a description for $Command parameter -<Name>" -TestCases $Parameters -Skip:(-not $Parameters) {
-                $Description | Should -Not -BeNullOrEmpty -Because "parameter $Name should have a description"
-            }
-
-            It "has at least one usage example for $Command" -TestCases $Help {
-                $Help.Examples.Example.Code.Count | Should -BeGreaterOrEqual 1
-            }
-
-            It "lists a description for $Command example: <Title>" -TestCases $Examples {
-                $Example.Remarks | Should -Not -BeNullOrEmpty -Because "example $($Example.Title) should have a description!"
+Describe "Help Content for <_>" -Tags @('analyze', 'help') -ForEach $CommandList {
+    BeforeAll {
+        #Renaming the automatic variable set in '-Foreach $CommandList
+        $Command = $_
+        $Help = Get-Help -Name $Command -Full | Select-Object -Property *
+        $Parameters = Get-Help -Name $Command -Parameter * -ErrorAction Ignore |
+        Where-Object { $_.Name -and $_.Name -notin $ShouldProcessParameters } |
+        ForEach-Object {
+            @{
+                Name        = $_.name
+                Description = $_.Description.Text
             }
         }
+        $Ast = @{
+            # Ast will be $null if the command is a compiled cmdlet
+            Ast        = (Get-Content -Path "function:/$Command" -ErrorAction Ignore).Ast
+            Parameters = $Parameters
+        }
+        $Examples = $Help.Help.Examples.Example | ForEach-Object { @{ Example = $_ } }
+    }
+
+    It "has help content" {
+        $Help | Should -Not -BeNullOrEmpty
+    }
+    It "contains a synopsis for <_>" {
+        $Help.Synopsis | Should -Not -BeNullOrEmpty
+    }
+
+    It "contains a description for <_>" {
+        $Help.Description | Should -Not -BeNullOrEmpty
+    }
+
+
+    # This will be skipped for compiled commands ($Ast.Ast will be $null)
+    It "has a help entry for all parameters of <_>" -TestCases $Ast -Skip:(-not ($Parameters -and $Ast.Ast)) {
+        @($Parameters).Count | Should -Be $Ast.Body.ParamBlock.Parameters.Count -Because 'the number of parameters in the help should match the number in the function script'
+    }
+
+    It "has a description for parameter -<Name>" -TestCases $Parameters -Skip:(-not $Parameters) {
+        $Description | Should -Not -BeNullOrEmpty -Because "parameter $Name should have a description"
+    }
+
+    It "has at least one usage example for <_>" {
+        $Help.Examples.Example.Code.Count | Should -BeGreaterOrEqual 1
+    }
+
+    It "lists a description for $Command example: <Title>" -TestCases $Examples {
+        $Example.Remarks | Should -Not -BeNullOrEmpty -Because "example $($Example.Title) should have a description!"
     }
 }


### PR DESCRIPTION
fixes #7 
[`Add-OrgElement` should take the Parent as Pipeline input and child as parameter(s)](https://app.gitkraken.com/glo/card/f763dee184d94181a7e986a92cdae56c)